### PR TITLE
[FIX] - PHP 8.4 Deprecation warning fix

### DIFF
--- a/Classes/Typolink/TopwirePageLinkBuilder.php
+++ b/Classes/Typolink/TopwirePageLinkBuilder.php
@@ -17,7 +17,7 @@ class TopwirePageLinkBuilder extends PageLinkBuilder
 
     public function __construct(
         ContentObjectRenderer $contentObjectRenderer,
-        TypoScriptFrontendController $typoScriptFrontendController = null
+        ?TypoScriptFrontendController $typoScriptFrontendController = null
     ) {
         parent::__construct($contentObjectRenderer, $typoScriptFrontendController);
         $defaultLinkBuilderClass = $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']['overriddenDefault'] ?? null;


### PR DESCRIPTION
Fixes: PHP Deprecated:  Topwire\Typolink\TopwirePageLinkBuilder::__construct(): Implicitly marking parameter $typoScriptFrontendController as nullable is deprecated, the explicit nullable type must be used instead in /vendor/topwire/topwire/Classes/Typolink/TopwirePageLinkBuilder.php on line 18