### PR TITLE
[FIX] - Frame WH fix when propagateUrl enabled

### DIFF
--- a/Classes/ViewHelpers/Turbo/FrameViewHelper.php
+++ b/Classes/ViewHelpers/Turbo/FrameViewHelper.php
@@ -69,7 +69,7 @@ class FrameViewHelper extends AbstractViewHelper
             // Handle page title for frames rendered in Fluid templates
             // @see TopwireContentObject for frames rendered via TypoScript
             $frontendController = $request->getAttribute('frontend.controller');
-            $pageTitle = $frontendController?->generatePageTitle();
+            $pageTitle = $frontendController?->generatePageTitle($request);
         }
 
         return (new FrameRenderer())->render(


### PR DESCRIPTION
Fixes: Too few arguments to function TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::generatePageTitle(), 0 passed in /vendor/topwire/topwire/Classes/ViewHelpers/Turbo/FrameViewHelper.php on line 72 and exactly 1 expected